### PR TITLE
Update Kotlin version 1.3.61 to 1.3.7

### DIFF
--- a/chapter5/build.gradle.kts
+++ b/chapter5/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   java
-  kotlin("jvm") version "1.3.61"
+  kotlin("jvm") version "1.3.70"
 }
 
 repositories {

--- a/chapter5/pom.xml
+++ b/chapter5/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.0.0</vertx.version>
     <logback-classic.version>1.2.3</logback-classic.version>
-    <kotlin.version>1.3.61</kotlin.version>
+    <kotlin.version>1.3.70</kotlin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <mainClass>chapter5.callbacks.Main</mainClass>


### PR DESCRIPTION
Chapter 5 has code examples with Kotlin coroutines that don't work.
There is a stacktrace:
```
Exception in thread "main" java.lang.NoClassDefFoundError: kotlin/coroutines/AbstractCoroutineContextKey
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:151)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:825)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:723)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:646)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:604)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at kotlinx.coroutines.CoroutineDispatcher.<clinit>(CoroutineDispatcher.kt)
	at kotlinx.coroutines.EventLoopKt.createEventLoop(EventLoop.kt:26)
	at kotlinx.coroutines.ThreadLocalEventLoop.getEventLoop$kotlinx_coroutines_core(EventLoop.common.kt:126)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at chapter5.kotlin.coroutines.intro.IntroKt.main(Intro.kt:8)
	at chapter5.kotlin.coroutines.intro.IntroKt.main(Intro.kt)
Caused by: java.lang.ClassNotFoundException: kotlin.coroutines.AbstractCoroutineContextKey
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:606)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 18 more
```
The problem can be fixed by updating `Kotlin` version.
A similar issue in Kotlin Github: https://github.com/Kotlin/kotlinx.coroutines/issues/1879