### PR TITLE
Chapter 6: Fix maven pom.xml

### DIFF
--- a/chapter6/pom.xml
+++ b/chapter6/pom.xml
@@ -99,6 +99,9 @@
           <annotationProcessors>
             <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
           </annotationProcessors>
+          <compilerArgs>
+            <arg>-Acodegen.output=${project.basedir}/src/main/generated</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
`Maven` imported project doesn't compile (with `Gradle` works).
Based on [vertx-codegen](https://github.com/vert-x3/vertx-codegen) docs, maven plugin should be configured with `compilerArgs`. 