### PR TITLE
changed version of testContainers to 1.5.1 to support Docker Desktop

### DIFF
--- a/part2-steps-challenge/build.gradle.kts
+++ b/part2-steps-challenge/build.gradle.kts
@@ -14,7 +14,7 @@ allprojects {
   extra["restAssuredVersion"] = "4.3.2"
   extra["logbackClassicVersion"] = "1.2.3"
   extra["assertjVersion"] = "3.18.0"
-  extra["testContainersVersion"] = "1.15.0"
+  extra["testContainersVersion"] = "1.15.1"
 }
 
 subprojects {

--- a/part2-steps-challenge/pom.xml
+++ b/part2-steps-challenge/pom.xml
@@ -33,7 +33,7 @@
     <rest-assured.version>4.3.2</rest-assured.version>
     <assertj-core.version>3.18.0</assertj-core.version>
     <junit-jupiter.version>1.13.0</junit-jupiter.version>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>
     <frontend-maven-plugin.nodeVersion>v12.16.3</frontend-maven-plugin.nodeVersion>
     <frontend-maven-plugin.yarnVersion>v1.22.4</frontend-maven-plugin.yarnVersion>


### PR DESCRIPTION
Version 1.5.1 of testcontainers allow build&run tests in Docker Desktop out of the box on Windows